### PR TITLE
Add ServiceNow inbound integration tests

### DIFF
--- a/changes/999.added
+++ b/changes/999.added
@@ -1,0 +1,1 @@
+Added new ServiceNow inbound integration using contrib-style mapping.

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -228,6 +228,7 @@ PLUGINS_CONFIG = {
         "enable_librenms": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_LIBRENMS", "false")),
         "enable_meraki": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_MERAKI")),
         "enable_servicenow": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_SERVICENOW")),
+        "enable_servicenow_inbound": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_SERVICENOW_INBOUND")),
         "enable_slurpit": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_SLURPIT")),
         "enable_solarwinds": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_SOLARWINDS")),
         "enable_vsphere": is_truthy(os.getenv("NAUTOBOT_SSOT_ENABLE_VSPHERE")),

--- a/docs/user/integrations/index.md
+++ b/docs/user/integrations/index.md
@@ -14,6 +14,7 @@ This Nautobot app supports the following integrations:
 - [LibreNMS](./librenms.md)
 - [Cisco Meraki](./meraki.md)
 - [ServiceNow](./servicenow.md)
+- [ServiceNow Inbound](./servicenow_inbound.md)
 - [Slurpit](./slurpit.md)
 - [SolarWinds](./solarwinds.md)
 - [vSphere](./vsphere.md)

--- a/docs/user/integrations/servicenow_inbound.md
+++ b/docs/user/integrations/servicenow_inbound.md
@@ -1,0 +1,8 @@
+# ServiceNow Inbound SSoT Integration
+
+This integration synchronizes data **from ServiceNow into Nautobot** using the contrib framework.
+
+ServiceNow tables and Nautobot models are mapped in a YAML file allowing for dynamic creation of DiffSync models.
+
+The job is available on the SSoT dashboard once the integration is enabled.
+

--- a/nautobot_ssot/__init__.py
+++ b/nautobot_ssot/__init__.py
@@ -112,6 +112,7 @@ class NautobotSSOTAppConfig(NautobotAppConfig):
         "enable_librenms": False,
         "enable_meraki": False,
         "enable_servicenow": False,
+        "enable_servicenow_inbound": False,
         "enable_slurpit": False,
         "enable_solarwinds": False,
         "enable_itential": False,

--- a/nautobot_ssot/integrations/servicenow_source/__init__.py
+++ b/nautobot_ssot/integrations/servicenow_source/__init__.py
@@ -1,0 +1,1 @@
+"""ServiceNow inbound integration."""

--- a/nautobot_ssot/integrations/servicenow_source/diffsync/__init__.py
+++ b/nautobot_ssot/integrations/servicenow_source/diffsync/__init__.py
@@ -1,0 +1,97 @@
+"""Dynamic DiffSync adapters for ServiceNow inbound integration."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Dict
+
+import yaml
+from diffsync import DiffSync
+from pydantic import create_model
+
+from nautobot_ssot.contrib.adapter import NautobotAdapter
+from nautobot_ssot.contrib.model import NautobotModel
+
+
+def create_model_class(name: str, model_path: str, identifiers: list[str], field_map: Dict[str, str]):
+    """Create a DiffSync model class dynamically."""
+    module_name, class_name = model_path.split(".", maxsplit=1)
+    orm_module = import_module(module_name)
+    orm_model = getattr(orm_module, class_name)
+
+    fields: Dict[str, tuple[type, None]] = {}
+    for field in identifiers:
+        fields[field] = (str, None)
+    for _, nb_field in field_map.items():
+        if nb_field not in fields:
+            fields[nb_field] = (str, None)
+
+    model_cls = create_model(name, **fields, __base__=NautobotModel)
+    model_cls._model = orm_model
+    model_cls._identifiers = tuple(identifiers)
+    model_cls._attributes = tuple(nb_field for nb_field in field_map.values())
+    return model_cls
+
+
+class ServiceNowDiffSync(DiffSync):
+    """DiffSync adapter using dynamic models loaded from mapping file."""
+
+    def __init__(self, mapping: Dict[str, Any], client=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mapping = mapping
+        self.client = client
+        self.models = {}
+        self._generate_models()
+        self.top_level = list(self.models.keys())
+
+    def load(self):
+        """Load data from ServiceNow using the provided client."""
+        if self.client is None:
+            return
+
+        for table, table_map in self.mapping.items():
+            model_cls = self.models[table]
+            identifiers = table_map.get("identifiers", [])
+            attr_map = table_map.get("attributes", {})
+            for record in self.client.all_table_entries(table):
+                ids = {field: record.get(field) for field in identifiers}
+                attrs = {
+                    nb_field: record.get(sn_field)
+                    for sn_field, nb_field in attr_map.items()
+                    if sn_field in record
+                }
+                model = model_cls(**ids, **attrs)
+                self.add(model)
+
+    def _generate_models(self):
+        for table, table_map in self.mapping.items():
+            nb_model_path = table_map["model"]
+            identifiers = table_map.get("identifiers", [])
+            attr_map = table_map.get("attributes", {})
+            model_cls = create_model_class(table, nb_model_path, identifiers, attr_map)
+            self.models[table] = model_cls
+            setattr(self, table, model_cls)
+
+
+class NautobotDynamicAdapter(NautobotAdapter):
+    """Nautobot adapter loading models dynamically from mapping."""
+
+    def __init__(self, mapping: Dict[str, Any], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mapping = mapping
+        self._generate_models()
+
+    def _generate_models(self):
+        for table, table_map in self.mapping.items():
+            nb_model_path = table_map["model"]
+            identifiers = table_map.get("identifiers", [])
+            attr_map = table_map.get("attributes", {})
+            model_cls = create_model_class(table, nb_model_path, identifiers, attr_map)
+            self.register_model(model_cls)
+
+
+def load_mapping(path) -> Dict[str, Any]:
+    """Load mapping file in YAML format."""
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+

--- a/nautobot_ssot/integrations/servicenow_source/jobs.py
+++ b/nautobot_ssot/integrations/servicenow_source/jobs.py
@@ -1,0 +1,62 @@
+"""ServiceNow to Nautobot sync job."""
+
+from diffsync.enum import DiffSyncFlags
+from django.templatetags.static import static
+from nautobot.extras.jobs import Job
+
+from nautobot_ssot.jobs.base import DataMapping, DataSource
+from nautobot_ssot.integrations.servicenow.utils import get_servicenow_parameters
+
+from .servicenow import ServiceNowClient
+from .diffsync import NautobotDynamicAdapter, ServiceNowDiffSync, load_mapping
+
+name = "SSoT - ServiceNow Inbound"  # pylint: disable=invalid-name
+
+
+class ServiceNowDataSource(DataSource, Job):  # pylint: disable=abstract-method
+    """Job syncing data from ServiceNow into Nautobot."""
+
+    class Meta:
+        name = "ServiceNow ➜ Nautobot"
+        data_source = "ServiceNow"
+        data_source_icon = static("nautobot_ssot_servicenow/ServiceNow_logo.svg")
+        description = "Synchronize data from ServiceNow into Nautobot."
+
+    @classmethod
+    def data_mappings(cls):
+        mapping = load_mapping("nautobot_ssot/integrations/servicenow_source/mapping.yml")
+        result = []
+        for table, table_map in mapping.items():
+            result.append(DataMapping(table_map["model"], None, table, None))
+        return tuple(result)
+
+    @classmethod
+    def config_information(cls):
+        configs = get_servicenow_parameters()
+        return {
+            "ServiceNow instance": configs.get("instance"),
+            "Username": configs.get("username"),
+        }
+
+    def load_source_adapter(self):
+        configs = get_servicenow_parameters()
+        client = ServiceNowClient(
+            instance=configs.get("instance"),
+            username=configs.get("username"),
+            password=configs.get("password"),
+        )
+        mapping = load_mapping("nautobot_ssot/integrations/servicenow_source/mapping.yml")
+        self.source_adapter = ServiceNowDiffSync(mapping=mapping, job=self, sync=self.sync, client=client)
+        self.source_adapter.load()
+
+    def load_target_adapter(self):
+        mapping = load_mapping("nautobot_ssot/integrations/servicenow_source/mapping.yml")
+        self.target_adapter = NautobotDynamicAdapter(mapping=mapping, job=self, sync=self.sync)
+        self.target_adapter.load()
+
+    def lookup_object(self, model_name, unique_id):
+        return None
+
+
+jobs = [ServiceNowDataSource]
+

--- a/nautobot_ssot/integrations/servicenow_source/mapping.yml
+++ b/nautobot_ssot/integrations/servicenow_source/mapping.yml
@@ -1,0 +1,15 @@
+# Mapping of ServiceNow tables to Nautobot models
+# Example structure:
+# <servicenow_table>:
+#   model: <nautobot_app_label>.<model_name>
+#   identifiers:
+#     - <field>
+#   attributes:
+#     <servicenow_field>: <nautobot_field>
+cmdb_ci_server:
+  model: dcim.device
+  identifiers:
+    - name
+  attributes:
+    serial_number: serial
+    sys_class_name: device_type__model

--- a/nautobot_ssot/integrations/servicenow_source/servicenow.py
+++ b/nautobot_ssot/integrations/servicenow_source/servicenow.py
@@ -1,0 +1,17 @@
+"""Simplified ServiceNow client using pysnc."""
+
+from typing import Any, Dict, Iterable
+
+import pysnc
+
+
+class ServiceNowClient:
+    """Wrapper around pysnc.Client with convenience helpers."""
+
+    def __init__(self, instance: str, username: str, password: str):
+        self.client = pysnc.ServiceNowClient(instance=instance, user=username, password=password)
+
+    def all_table_entries(self, table: str, query: Dict[str, Any] | None = None) -> Iterable[Dict[str, Any]]:
+        """Yield all records from a table."""
+        resource = self.client.resource(api_path=f"/table/{table}")
+        yield from resource.get(query=query or {}, stream=True).all()

--- a/nautobot_ssot/tests/servicenow_source/__init__.py
+++ b/nautobot_ssot/tests/servicenow_source/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ServiceNow inbound integration."""

--- a/nautobot_ssot/tests/servicenow_source/fixtures/servers.json
+++ b/nautobot_ssot/tests/servicenow_source/fixtures/servers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "test-server-01",
+    "serial_number": "ABC123",
+    "sys_class_name": "TestModel"
+  }
+]

--- a/nautobot_ssot/tests/servicenow_source/test_inbound.py
+++ b/nautobot_ssot/tests/servicenow_source/test_inbound.py
@@ -1,0 +1,76 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from nautobot.core.testing import TransactionTestCase
+from nautobot.extras.models import JobResult
+
+from nautobot_ssot.integrations.servicenow_source.diffsync import (
+    ServiceNowDiffSync,
+    load_mapping,
+    create_model_class,
+)
+from nautobot_ssot.integrations.servicenow_source.jobs import ServiceNowDataSource
+
+
+FIXTURE_PATH = "./nautobot_ssot/tests/servicenow_source/fixtures/servers.json"
+
+
+class MappingTestCase(TransactionTestCase):
+    """Validate dynamic model creation."""
+
+    databases = ("default", "job_logs")
+
+    def test_create_model_class(self):
+        mapping = load_mapping("nautobot_ssot/integrations/servicenow_source/mapping.yml")
+        table_map = mapping["cmdb_ci_server"]
+        model_cls = create_model_class(
+            "cmdb_ci_server",
+            table_map["model"],
+            table_map["identifiers"],
+            table_map["attributes"],
+        )
+        obj = model_cls(name="example", serial="XYZ")
+        self.assertEqual(obj.name, "example")
+        self.assertEqual(obj.serial, "XYZ")
+
+
+class ServiceNowDiffSyncTestCase(TransactionTestCase):
+    """Ensure ServiceNowDiffSync loads data correctly."""
+
+    databases = ("default", "job_logs")
+
+    def setUp(self):
+        with open(FIXTURE_PATH, encoding="utf-8") as handle:
+            self.records = json.load(handle)
+
+    def test_load(self):
+        mapping = load_mapping("nautobot_ssot/integrations/servicenow_source/mapping.yml")
+
+        class MockClient:
+            def all_table_entries(self, table, query=None):  # pylint: disable=unused-argument
+                if table == "cmdb_ci_server":
+                    return self.records
+                return []
+
+        diff = ServiceNowDiffSync(mapping=mapping, client=MockClient(), job=MagicMock(), sync=None)
+        diff.load()
+        servers = diff.get_all("cmdb_ci_server")
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers[0].name, "test-server-01")
+        self.assertEqual(servers[0].serial, "ABC123")
+
+    @patch("nautobot_ssot.integrations.servicenow_source.jobs.get_servicenow_parameters")
+    @patch("nautobot_ssot.integrations.servicenow_source.jobs.ServiceNowClient")
+    def test_job_load_source_adapter(self, mock_client_cls, mock_params):
+        mock_params.return_value = {"instance": "dev", "username": "user", "password": "pass"}
+        mock_client = MagicMock()
+        mock_client.all_table_entries.return_value = self.records
+        mock_client_cls.return_value = mock_client
+
+        job = ServiceNowDataSource()
+        job.job_result = JobResult.objects.create(name=job.class_path, task_name="test", worker="default")
+        job.load_source_adapter()
+
+        self.assertIsInstance(job.source_adapter, ServiceNowDiffSync)
+        self.assertEqual(len(job.source_adapter.get_all("cmdb_ci_server")), 1)
+


### PR DESCRIPTION
## Summary
- create ServiceNow inbound fixtures and unit tests
- implement `ServiceNowDiffSync.load` to load records from mocked ServiceNow

## Testing
- `poetry run invoke tests` *(fails: Command not found: invoke)*

------
https://chatgpt.com/codex/tasks/task_e_685f01759c5c832889b4e24f6a612d1c